### PR TITLE
fix/database category parent_id

### DIFF
--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -31,7 +31,7 @@ const Slug = props => {
       setLock(true)
     } else {
       if (!lock && post?.blockMap?.block) {
-        post.content = Object.keys(post.blockMap.block).filter(key => post.blockMap.block[key]?.value.parent_id === post.id)
+        post.content = Object.keys(post.blockMap.block).filter(key => post.blockMap.block[key]?.value?.parent_id === post.id)
         post.toc = getPageTableOfContents(post, post.blockMap)
       }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes a bug in the `pages/[...slug].js` file where the `parent_id` property was not being accessed correctly, causing issues with the content and table of contents. 

### Detailed summary
- Fixed bug where `parent_id` property was not being accessed correctly
- Updated filter function to include `?.value` to properly access `parent_id`
- `post.content` and `post.toc` now properly generated based on corrected filter function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->