### PR TITLE
图注深色适配

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -919,6 +919,7 @@ code[class*='language-'] {
   font-size: 14px;
   line-height: 1.4;
   color: var(--fg-color-3);
+  @apply dark:text-gray-300
 }
 
 .notion-callout {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a dark text color to the `notion.css` file for improved readability.

### Detailed summary
- Added `dark:text-gray-300` to `color` property for improved readability in dark mode.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->