### PR TITLE
懒加载占位图可配置

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -356,6 +356,7 @@ const BLOG = {
       process.env.NEXT_PUBLIC_DESCRIPTION || '这是一个由NotionNext生成的站点', // 站点描述，被notion中的页面描述覆盖
 
   // 网站图片
+  IMG_LAZY_LOAD_PLACEHOLDER: process.env.NEXT_PUBLIC_IMG_LAZY_LOAD_PLACEHOLDER || 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==', // 懒加载占位图片地址，支持base64或url
   IMG_URL_TYPE: process.env.NEXT_PUBLIC_IMG_TYPE || 'Notion', // 此配置已失效，请勿使用；AMAZON方案不再支持，仅支持Notion方案。 ['Notion','AMAZON'] 站点图片前缀 默认 Notion:(https://notion.so/images/xx) ， AMAZON(https://s3.us-west-2.amazonaws.com/xxx)
   IMG_SHADOW: process.env.NEXT_PUBLIC_IMG_SHADOW || false, // 文章图片是否自动添加阴影
 

--- a/components/LazyImage.js
+++ b/components/LazyImage.js
@@ -1,20 +1,6 @@
+import BLOG from '@/blog.config'
 import Head from 'next/head'
 import React, { useEffect, useRef, useState } from 'react'
-
-/**
- * 默认懒加载占位图
- */
-const loadingSVG = (
-    <svg
-        width="100"
-        height="100"
-        viewBox="0 0 100 100"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="#ccc"
-    >
-        <circle cx="50" cy="50" r="42" strokeWidth="8" />
-    </svg>
-)
 
 /**
  * 图片懒加载
@@ -26,7 +12,7 @@ export default function LazyImage({
   id,
   src,
   alt,
-  placeholderSrc = loadingSVG,
+  placeholderSrc = BLOG.IMG_LAZY_LOAD_PLACEHOLDER,
   className,
   width,
   height,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Updated `IMG_LAZY_LOAD_PLACEHOLDER` value in `blog.config.js` to use `process.env.NEXT_PUBLIC_IMG_LAZY_LOAD_PLACEHOLDER` or a default placeholder image.
- Removed the unused `loadingSVG` variable in `components/LazyImage.js`.
- Updated `placeholderSrc` default value in `LazyImage` component to use `BLOG.IMG_LAZY_LOAD_PLACEHOLDER` from `blog.config.js`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->