### PR TITLE
config-img-shadow

### DIFF
--- a/components/ExternalPlugins.js
+++ b/components/ExternalPlugins.js
@@ -5,7 +5,7 @@ import WebWhiz from './Webwhiz'
 import TianLiGPT from './TianliGPT'
 import { GlobalStyle } from './GlobalStyle'
 
-import { CUSTOM_EXTERNAL_CSS, CUSTOM_EXTERNAL_JS, IMG_SHADOW } from '@/blog.config'
+import { CUSTOM_EXTERNAL_CSS, CUSTOM_EXTERNAL_JS } from '@/blog.config'
 import { isBrowser, loadExternalResource } from '@/lib/utils'
 
 const TwikooCommentCounter = dynamic(() => import('@/components/TwikooCommentCounter'), { ssr: false })
@@ -79,6 +79,7 @@ const ExternalPlugin = (props) => {
   const TIANLI_KEY = siteConfig('TianliGPT_KEY')
   const GLOBAL_JS = siteConfig('GLOBAL_JS')
   const CLARITY_ID = siteConfig('CLARITY_ID')
+  const IMG_SHADOW = siteConfig('IMG_SHADOW')
 
   // 自定义样式css和js引入
   if (isBrowser) {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the `IMG_SHADOW` import from `ExternalPlugins.js` and instead retrieves it from the `siteConfig` function.

### Detailed summary
- Removed `IMG_SHADOW` import from `ExternalPlugins.js`
- Added `IMG_SHADOW` variable assignment from `siteConfig` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->