### PR TITLE
gitbook 减少广告

### DIFF
--- a/themes/gitbook/index.js
+++ b/themes/gitbook/index.js
@@ -362,8 +362,8 @@ const LayoutSlug = props => {
                 <ArticleAround prev={prev} next={next} />
               )}
 
-              <AdSlot />
-              <WWAds className='w-full' orientation='horizontal' />
+              {/* <AdSlot />
+              <WWAds className='w-full' orientation='horizontal' /> */}
 
               <Comment frontMatter={post} />
             </section>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on commenting out two components, `AdSlot` and `WWAds`, in the `themes/gitbook/index.js` file, likely to disable their rendering without removing the code entirely.

### Detailed summary
- Commented out the `AdSlot` component.
- Commented out the `WWAds` component with a `className` of 'w-full' and an `orientation` of 'horizontal'.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->