### PR TITLE
starter主题-Logo相关

### DIFF
--- a/components/LazyImage.js
+++ b/components/LazyImage.js
@@ -18,6 +18,7 @@ export default function LazyImage({
   height,
   title,
   onLoad,
+  onClick,
   style
 }) {
   const maxWidth = siteConfig('IMAGE_COMPRESS_WIDTH')
@@ -122,7 +123,9 @@ export default function LazyImage({
   if (style) {
     imgProps.style = style
   }
-
+  if (onClick) {
+    imgProps.onClick = onClick
+  }
   return (
     <>
       {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/themes/starter/components/Logo.js
+++ b/themes/starter/components/Logo.js
@@ -1,5 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable @next/next/no-html-link-for-pages */
+import LazyImage from '@/components/LazyImage'
 import { siteConfig } from '@/lib/config'
 import { useGlobal } from '@/lib/global'
 import throttle from 'lodash.throttle'
@@ -48,14 +49,14 @@ export const Logo = props => {
       <div className='navbar-logo flex items-center w-full py-5 cursor-pointer'>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         {logo && (
-          <img
+          <LazyImage
+            priority
             onClick={() => {
               router.push('/')
             }}
             src={logo}
-            height={14}
             alt='logo'
-            className='header-logo w-full mr-1'
+            className='header-logo mr-1 h-8'
           />
         )}
         {/* logo文字 */}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces an `onClick` prop to the `LazyImage` component and updates the `Logo` component to use `LazyImage` instead of a standard `img` tag, enhancing interactivity by allowing click events.

### Detailed summary
- Added `onClick` prop to `LazyImage` component.
- Updated `Logo` component to use `LazyImage` instead of `img`.
- Set `onClick` in `Logo` to navigate to the homepage.
- Adjusted `className` for `LazyImage` in `Logo` for styling consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->