### PR TITLE
sitemap.xml问题

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -34,6 +34,7 @@ export const siteConfig = (key, defaultVal = null, extendConfig = {}) => {
     case 'POST_URL_PREFIX_MAPPING_CATEGORY':
     case 'IS_TAG_COLOR_DISTINGUISHED':
     case 'TAG_SORT_BY_COUNT':
+    case 'LINK':
       return convertVal(extendConfig[key] || defaultVal || BLOG[key])
     default:
   }

--- a/lib/notion/getNotionConfig.js
+++ b/lib/notion/getNotionConfig.js
@@ -36,7 +36,7 @@ export async function getConfigMapFromConfigPage(allPages) {
   })
 
   if (!configPage) {
-    console.warn('[Notion配置] 未找到配置页面')
+    // console.warn('[Notion配置] 未找到配置页面')
     return null
   }
   const configPageId = configPage.id
@@ -51,11 +51,11 @@ export async function getConfigMapFromConfigPage(allPages) {
   }
 
   if (!content) {
-    console.warn(
-      '[Notion配置] 未找到配置表格',
-      pageRecordMap.block[configPageId],
-      pageRecordMap.block[configPageId].value
-    )
+    // console.warn(
+    //   '[Notion配置] 未找到配置表格',
+    //   pageRecordMap.block[configPageId],
+    //   pageRecordMap.block[configPageId].value
+    // )
     return null
   }
 
@@ -66,11 +66,11 @@ export async function getConfigMapFromConfigPage(allPages) {
 
   // eslint-disable-next-line no-constant-condition, no-self-compare
   if (!configTableId) {
-    console.warn(
-      '[Notion配置]未找到配置表格数据',
-      pageRecordMap.block[configPageId],
-      pageRecordMap.block[configPageId].value
-    )
+    // console.warn(
+    //   '[Notion配置]未找到配置表格数据',
+    //   pageRecordMap.block[configPageId],
+    //   pageRecordMap.block[configPageId].value
+    // )
     return null
   }
 

--- a/lib/sitemap.xml.js
+++ b/lib/sitemap.xml.js
@@ -1,25 +1,29 @@
-import BLOG from '@/blog.config'
 import fs from 'fs'
-
-export async function generateSitemapXml({ allPages }) {
+import { siteConfig } from './config'
+/**
+ * 生成站点地图
+ * @param {*} param0
+ */
+export async function generateSitemapXml({ allPages, NOTION_CONFIG }) {
+  const link = siteConfig('LINK', null, NOTION_CONFIG)
   const urls = [
     {
-      loc: `${BLOG.LINK}`,
+      loc: `${link}`,
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     },
     {
-      loc: `${BLOG.LINK}/archive`,
+      loc: `${link}/archive`,
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     },
     {
-      loc: `${BLOG.LINK}/category`,
+      loc: `${link}/category`,
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     },
     {
-      loc: `${BLOG.LINK}/tag`,
+      loc: `${link}/tag`,
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     }
@@ -30,7 +34,7 @@ export async function generateSitemapXml({ allPages }) {
       ? post?.slug?.slice(1)
       : post.slug
     urls.push({
-      loc: `${BLOG.LINK}/${slugWithoutLeadingSlash}`,
+      loc: `${link}/${slugWithoutLeadingSlash}`,
       lastmod: new Date(post?.publishDay).toISOString().split('T')[0],
       changefreq: 'daily'
     })


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new case for handling `LINK` in the configuration, modifies the `generateSitemapXml` function to utilize `siteConfig`, and comments out several warning logs in the `getNotionConfig` module.

### Detailed summary
- Added case `'LINK'` in `lib/config.js`.
- Commented out console warnings in `lib/notion/getNotionConfig.js`.
- Updated `generateSitemapXml` function in `lib/sitemap.xml.js` to accept `NOTION_CONFIG` and use `siteConfig('LINK')` for URL generation.
- Updated URLs in the sitemap to use the new `link` variable instead of `BLOG.LINK`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->